### PR TITLE
Refactor: move mock implementations into dedicated act/mock package

### DIFF
--- a/act/Makefile
+++ b/act/Makefile
@@ -7,7 +7,7 @@ PYTHON := python3
 # スクリプトのパス
 SCRIPT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 PROJECT_ROOT := $(abspath $(SCRIPT_DIR)..)
-MOCK_SCRIPT := $(SCRIPT_DIR)run_mock.py
+MOCK_SCRIPT := $(SCRIPT_DIR)mock/run_mock.py
 RUN_SCRIPT := $(SCRIPT_DIR)run.py
 
 help:

--- a/act/README.md
+++ b/act/README.md
@@ -24,7 +24,6 @@ act/
 │   └── README.md        # configパッケージの詳細説明
 ├── sensors/             # 物理センサー実装
 │   ├── __init__.py
-│   ├── mock.py          # 開発用モック（MockTOFSensor）
 │   └── tof.py           # 実機用（TOFSensor - VL53L0X）
 ├── perception/          # 知覚モジュール実装
 │   ├── __init__.py
@@ -34,13 +33,16 @@ act/
 │   └── wall_follow.py   # 左壁沿いP制御
 ├── actuation/           # 駆動モジュール実装
 │   ├── __init__.py
-│   ├── pwm.py           # pigpioを使用したPWM制御実装
-│   └── mock.py          # 開発・テスト用のモック実装
+│   └── pwm.py           # pigpioを使用したPWM制御実装
+├── mock/                # モック実装
+│   ├── __init__.py
+│   ├── actuation.py     # 開発・テスト用のMockActuation実装
+│   ├── sensors.py       # 開発・テスト用のMockTOFSensor実装
+│   └── run_mock.py      # モック実行スクリプト
 ├── orchestrator/        # オーケストレーター
 │   ├── __init__.py
 │   └── orchestrator.py  # センサー→知覚→判断→駆動のループ
 ├── run.py               # 実機実行スクリプト
-├── run_mock.py          # モック実行スクリプト
 ├── Makefile             # ビルド・実行用Makefile
 └── README.md            # このファイル
 ```
@@ -86,8 +88,8 @@ TOFセンサー（距離センサー）の実装モジュール。
 - **`tof.py`**: 実機用のVL53L0X実装（`TOFSensor`クラス）
   - 3つのVL53L0Xセンサー（前・左・右）をI2Cで制御
   - XSHUTピンを使用してI2Cアドレスを設定
-- **`mock.py`**: 開発・テスト用のモック実装（`MockTOFSensor`クラス）
-  - 固定値、ランダム値、動的変化（時間経過で値が変化）に対応
+
+モック実装は `mock/` ディレクトリに集約しています。
 
 ### `perception/`
 距離データから特徴量を抽出する知覚モジュールの実装。
@@ -112,8 +114,17 @@ TOFセンサー（距離センサー）の実装モジュール。
 - **`pwm.py`**: `PWMActuation`クラス
   - pigpioを使用したPWM制御実装
   - PCA9685を使用してESCとサーボを制御
-- **`mock.py`**: `MockActuation`クラス
-  - 開発・テスト用のモック実装（実際のハードウェアは使用しない）
+
+開発・テスト用のモック実装は `mock/actuation.py` に移動しています。
+
+### `mock/`
+開発・テスト用のモック実装とスクリプトを集約したディレクトリ。
+
+- **`sensors.py`**: `MockTOFSensor`クラス
+  - 固定値、ランダム値、動的変化（時間経過で値が変化）に対応
+- **`actuation.py`**: `MockActuation`クラス
+  - 実際のハードウェアは使用せず、`set_us()`の動作をシミュレート
+- **`run_mock.py`**: モック実行スクリプト
 
 ### `orchestrator/`
 全モジュールを統合して実行するオーケストレーター。
@@ -136,7 +147,7 @@ make mock_run
 make run_mock
 
 # 直接実行
-python3 run_mock.py
+python3 mock/run_mock.py
 ```
 
 ### 実機モード（Raspberry Pi）
@@ -166,10 +177,12 @@ make clean     # Pythonキャッシュファイルを削除
 
 ```python
 from act.orchestrator import Orchestrator
-from act.sensors import TOFSensor, MockTOFSensor
+from act.sensors import TOFSensor
+from act.mock import MockTOFSensor
 from act.perception import WallPositionPerception
 from act.decision import WallFollowDecision
-from act.actuation import PWMActuation, MockActuation
+from act.actuation import PWMActuation
+from act.mock import MockActuation
 from act.domain.actuation import ActuationCalibration
 
 # モックモードの場合

--- a/act/actuation/__init__.py
+++ b/act/actuation/__init__.py
@@ -1,7 +1,7 @@
 # actuation パッケージ
 # コマンドを物理信号（PWM等）に変換・出力する駆動モジュールの実装
 
-from .mock import MockActuation
+from ..mock.actuation import MockActuation
 
 # pwm.pyのインポートは条件付き（実機環境でのみ利用可能）
 try:

--- a/act/actuation/pwm.py
+++ b/act/actuation/pwm.py
@@ -29,8 +29,8 @@ def _is_raspberry_pi() -> bool:
 _use_mock = not _is_raspberry_pi()
 
 if _use_mock:
-    # モックモジュールを使用（実際にはmock.pyを使うべきだが、ここでは警告のみ）
-    print("[WARNING] PWM actuation: Not on Raspberry Pi, but using pwm.py. Consider using mock.py", file=sys.stderr)
+    # モックモジュールを使用（実際にはmock/actuation.pyを使うべきだが、ここでは警告のみ）
+    print("[WARNING] PWM actuation: Not on Raspberry Pi, but using pwm.py. Consider using mock/actuation.py", file=sys.stderr)
     # モックモジュールをインポート（kudou_testから）
     try:
         # kudou_testディレクトリをパスに追加
@@ -41,7 +41,7 @@ if _use_mock:
         from hardware_import import board, busio
         from adafruit_pca9685 import PCA9685
     except ImportError:
-        raise ImportError("Cannot import hardware modules. Use mock.py for non-Raspberry Pi environments.")
+        raise ImportError("Cannot import hardware modules. Use mock/actuation.py for non-Raspberry Pi environments.")
 else:
     # 実機モジュールをインポート
     import board

--- a/act/mock/__init__.py
+++ b/act/mock/__init__.py
@@ -1,0 +1,9 @@
+"""Mock implementations and utilities."""
+
+from .actuation import MockActuation
+from .sensors import MockTOFSensor
+
+__all__ = [
+    "MockActuation",
+    "MockTOFSensor",
+]

--- a/act/mock/actuation.py
+++ b/act/mock/actuation.py
@@ -1,5 +1,5 @@
 # --------------------------------
-# actuation/mock.py
+# mock/actuation.py
 # モック実装（開発・テスト用）
 # --------------------------------
 from __future__ import annotations

--- a/act/mock/run_mock.py
+++ b/act/mock/run_mock.py
@@ -3,10 +3,10 @@
 モック実装でオーケストレーターを実行するスクリプト
 """
 from act.orchestrator import Orchestrator
-from act.sensors import MockTOFSensor
+from act.mock import MockTOFSensor
 from act.perception import WallPositionPerception
 from act.decision import WallFollowDecision
-from act.actuation import MockActuation
+from act.mock import MockActuation
 from act.domain.actuation import ActuationCalibration
 
 

--- a/act/mock/sensors.py
+++ b/act/mock/sensors.py
@@ -1,5 +1,5 @@
 # --------------------------------
-# sensors/mock.py
+# mock/sensors.py
 # TOFセンサーのモック実装（開発・テスト用）
 # --------------------------------
 from __future__ import annotations
@@ -9,7 +9,7 @@ import random
 import time
 from typing import Optional, Tuple
 
-from .tof import TOFReadings
+from ..sensors.tof import TOFReadings
 from ..domain.distance import DistanceData
 
 

--- a/act/sensors/__init__.py
+++ b/act/sensors/__init__.py
@@ -1,7 +1,7 @@
 # sensors パッケージ
 # TOFセンサー（距離センサー）の実装モジュール
 
-from .mock import MockTOFSensor
+from ..mock.sensors import MockTOFSensor
 
 # TOFSensorとTOFReadingsは条件付きインポート（ハードウェアモジュールが必要）
 try:


### PR DESCRIPTION
### Motivation
- Organize mock-related code into a single `act/mock` package to avoid mixed placement of mock modules under `act/`.
- Make mock runner and examples point to the consolidated mock package for clearer developer workflow.
- Update messaging and references so other modules that hint at mock usage refer to the new location.

### Description
- Added a new `act/mock` package with `actuation.py`, `sensors.py`, `run_mock.py`, and an `__init__.py` that exports `MockActuation` and `MockTOFSensor`.
- Moved existing `act/actuation/mock.py`, `act/sensors/mock.py`, and `act/run_mock.py` into the new `act/mock` package and adjusted internal module docstrings/paths.
- Updated package entry points to preserve compatibility by changing `act/actuation/__init__.py` and `act/sensors/__init__.py` to import mocks from `..mock.*`.
- Updated `Makefile` and `README.md` to point to `mock/run_mock.py`, and revised warnings in `act/actuation/pwm.py` to reference `mock/actuation.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b07459270832a93bc57eca14e49fd)