### PR TITLE
Add left-front sensor timing log

### DIFF
--- a/prototype/orchestrator/orchestrator.py
+++ b/prototype/orchestrator/orchestrator.py
@@ -324,12 +324,22 @@ class Orchestrator:
         timestamp = elapsed_time
         l_dist = distance_data.left_mm
         lf_dist = distance_data.left_front_mm
+        front_dist = distance_data.front_mm
         error = features.error_from_target
         steer = command.steer
         speed = command.throttle
         steer_pwm = telemetry.steer_pwm_us if telemetry.steer_pwm_us is not None else 0
         throttle_pwm = telemetry.throttle_pwm_us if telemetry.throttle_pwm_us is not None else 0
         status_str = telemetry.status.value if hasattr(telemetry.status, 'value') else str(telemetry.status)
+
+        if self._timing_logger:
+            self._timing_logger.info(
+                "t=%.3fs loop=detail metric=sensor front_mm=%.0f left_mm=%.0f left_front_mm=%.0f",
+                timestamp,
+                front_dist,
+                l_dist,
+                lf_dist,
+            )
         
         # パイプ区切りのテーブル形式で出力
         # TIME: 5文字幅（右寄せ）、小数点1桁 + "s"


### PR DESCRIPTION
### Motivation
- Include the left-front (and front/left) TOF sensor readings in the timing logger so per-loop sensor detail is available for monitoring and debugging.

### Description
- In `prototype/orchestrator/orchestrator.py` added extraction of `front_mm` from `DistanceData` and emit a detailed timing log line when `_timing_logger` is enabled using the format `t=... loop=detail metric=sensor front_mm=... left_mm=... left_front_mm=...`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69789679d240832a9e522f100f7cb090)