### PR TITLE
importエラーを解消

### DIFF
--- a/prototype/decision/__init__.py
+++ b/prototype/decision/__init__.py
@@ -2,7 +2,6 @@
 # 特徴量から操舵・速度を決定する判断モジュールの実装
 
 from .wall_follow import WallFollowDecision
-from .integral import IntegralController
 from .differential import DifferentialController
 
-__all__ = ["WallFollowDecision", "IntegralController", "DifferentialController"]
+__all__ = ["WallFollowDecision", "DifferentialController"]


### PR DESCRIPTION
mainブランチにてmake run失敗したため、ブランチを切り修正しました。

mergeされていたwall_followみたいな名前のブランチは正常にmakeできていました。

* main
(venv) user03@hostname03:~/codes/Automational-Minidcar/prototype $ make run
==========================================
Running in REAL mode (requires Raspberry Pi)
==========================================
PYTHONPATH=/home/user03/codes/Automational-Minidcar python3 /home/user03/codes/Automational-Minidcar/prototype/run.py
Traceback (most recent call last):
  File "/home/user03/codes/Automational-Minidcar/prototype/run.py", line 8, in <module>
    from prototype.decision import WallFollowDecision
  File "/home/user03/codes/Automational-Minidcar/prototype/decision/__init__.py", line 5, in <module>
    from .integral import IntegralController
ModuleNotFoundError: No module named 'prototype.decision.integral'
make: *** [Makefile:22: run] Error 1

不適切であれば訂正お願いします。